### PR TITLE
Fixes for rbac and serviceAccountName generation

### DIFF
--- a/charts/dex/templates/_helpers.tpl
+++ b/charts/dex/templates/_helpers.tpl
@@ -32,6 +32,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "dex.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "dex.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create secret key from environment variables
 */}}
 {{- define "dex.envkey" -}}

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      serviceAccountName: {{ template "dex.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/dex/templates/rbac.yaml
+++ b/charts/dex/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -41,7 +41,7 @@ roleRef:
   name: {{ template "dex.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ default "default" .Values.serviceAccount.name }}
+  name: {{ template "dex.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -55,8 +55,8 @@ roleRef:
   name: {{ template "dex.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ default "default" .Values.serviceAccount.name }}
-  namespace: {{ template "dex.fullname" . }}
+  name: {{ template "dex.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 
 

--- a/charts/dex/templates/serviceaccount.yaml
+++ b/charts/dex/templates/serviceaccount.yaml
@@ -2,11 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if .Values.serviceAccount.name }}
-  name: {{ .Values.serviceAccount.name }}
-  {{- else }}
-  name: {{ template "dex.fullname" . }}
-  {{- end }}
+  name: {{ template "dex.serviceAccountName" . }}
   labels:
     app: {{ template "dex.fullname" . }}
     env: {{ default "dev" .Values.global.deployEnv }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -28,14 +28,16 @@ ingress:
   #    hosts:
   #      - dex.example.com
 
-# rbac will use the 'default' Service Account if 'serviceAccount.create' is false
 rbac:
+  # Specifies whether RBAC resources should be created
   create: true
-
+  
 serviceAccount:
+  # Specifies whether a ServiceAccount should be created
   create: true
-  # Service Account name defaults to an automatically generated name
-  #name: "custom-name"
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Using best-practise here as per:
https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/rbac.md

- Generate service-account name using a template
- Fix RoleBinding namespace
- Generate rbac rules based on rbac.create (not serviceAccount.create)