### PR TITLE
Add support for self-signed certificates at container runtime 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,15 @@ RUN apk add --update ca-certificates openssl curl
 
 COPY --from=0 /go/src/github.com/mintel/dex-k8s-authenticator /app
 
-# Add any required certs here... and run update-ca-certificates
+# Add any required certs/key by mounting a volume on /certs - Entrypoint will copy them and run update-ca-certificates at startup
+RUN mkdir -p /certs
+
 WORKDIR /app
 
-ENTRYPOINT ["/app/bin/dex-k8s-authenticator"]
+COPY entrypoint.sh /
+RUN chmod a+x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["--help"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.2-alpine
+FROM golang:1.9.4-alpine3.7
 
 RUN apk add --no-cache --update alpine-sdk bash
 
@@ -6,7 +6,7 @@ COPY . /go/src/github.com/mintel/dex-k8s-authenticator
 WORKDIR /go/src/github.com/mintel/dex-k8s-authenticator
 RUN make get && make 
 
-FROM alpine:3.4
+FROM alpine:3.7
 # Dex connectors, such as GitHub and Google logins require root certificates.
 # Proper installations should manage those certificates, but it's a bad user
 # experience when this doesn't work out of the box.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ required settings.
 
 ## SSL
 
-You can update the Dockerfile and add any required root-certs to `/usr/local/share/ca-certificates/`, then run `update-ca-certificates`
+### Docker
+
+Mount a directory containing your self signed certificates to */certs* and the entrypoint will update the local trust store before starting dex-k8s-authenticator
+
+    docker run --rm -t -i -v /tmp/certs:/certs:ro -v /tmp/config.yml:/tmp/config.yml:ro mintel/dex-k8s-authenticator:latest --config /tmp/config.yml
+### HELM
+
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ required settings.
 Mount a directory containing your self signed certificates to */certs* and the entrypoint will update the local trust store before starting dex-k8s-authenticator
 
     docker run --rm -t -i -v /tmp/certs:/certs:ro -v /tmp/config.yml:/tmp/config.yml:ro mintel/dex-k8s-authenticator:latest --config /tmp/config.yml
+
 ### HELM
+
+Add list of Certificates to your values.yaml file, certificates need to be base64 encoded and their names need to end with either ".crt" or ".pem"
 
 
 ## Alternatives

--- a/charts/dex-k8s-authenticator/templates/ca_secrets.yaml
+++ b/charts/dex-k8s-authenticator/templates/ca_secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.caCerts.enabled }}
+{{- range .Values.caCerts.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "dex-k8s-authenticator.name" $ }}-{{ .name }}
+  labels:
+    app: {{ template "dex-k8s-authenticator.name" $ }}
+    env: {{ default "dev" $.Values.global.deployEnv }}
+    chart: {{ template "dex-k8s-authenticator.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+type: Opaque
+data:
+  {{ .name }}: {{ .value }}
+---
+{{- end }}
+{{- end }}

--- a/charts/dex-k8s-authenticator/templates/deployment.yaml
+++ b/charts/dex-k8s-authenticator/templates/deployment.yaml
@@ -43,6 +43,13 @@ spec:
         - name: config
           subPath: config.yaml
           mountPath: /app/config.yaml
+{{- if .Values.caCerts.enabled }}
+{{- range .Values.caCerts.secrets }}
+        - name: {{ template "dex-k8s-authenticator.name" $ }}-{{ .name }}
+          subPath: {{ .name }}
+          mountPath: /certs/{{ .name }}
+{{- end }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}
@@ -61,3 +68,10 @@ spec:
       - name: config
         configMap:
           name: {{ template "dex-k8s-authenticator.name" . }}
+{{- if .Values.caCerts.enabled }}
+{{- range .Values.caCerts.secrets }}
+      - name: {{ template "dex-k8s-authenticator.name" $ }}-{{ .name }}
+        configMap:
+          name: {{ template "dex-k8s-authenticator.name" $ }}-{{ .name }}
+{{- end }}
+{{- end }}

--- a/charts/dex-k8s-authenticator/values.yaml
+++ b/charts/dex-k8s-authenticator/values.yaml
@@ -57,6 +57,19 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+caCerts: 
+  enabled: false
+  secrets: {}
+  # Array of Self Signed Certificates - single line base64 encoded 
+  # cat CA.crt | base64 -w 0
+  # name should end in either .crt or .pem since it is the name with which it will be mounted on the filesysystem
+  #secrets:
+  #- name: CA.crt
+  #  value: LS0tLS1......X2F
+  #- name: CA2.crt
+  #  value: DS1tFA1......X2F
+
+
 nodeSelector: {}
 
 tolerations: []

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ ! -z "$(ls -A /certs)" ]; then
+  cp /certs/*.crt /certs/*.pem /usr/local/share/ca-certificates/
+  update-ca-certificates
+fi
+
+# Execute dex-k8s-authenticator with any argument passed to docker run
+/app/bin/dex-k8s-authenticator $@


### PR DESCRIPTION
Use entrypoint.sh to update CA certificates store at runtime rather than docker container buildtime 