### PR TITLE
Fix service port to bind to ingress in helm chart

### DIFF
--- a/charts/dex-k8s-authenticator/templates/ingress.yaml
+++ b/charts/dex-k8s-authenticator/templates/ingress.yaml
@@ -35,6 +35,6 @@ spec:
       - path: {{ $ingressPath }}
         backend:
           serviceName: {{ $fullName }}
-          servicePort: http
+          servicePort: {{ $servicePort }}
   {{- end }}
 {{- end }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -35,6 +35,6 @@ spec:
       - path: {{ $ingressPath }}
         backend:
           serviceName: {{ $fullName }}
-          servicePort: http
+          servicePort: {{ $servicePort }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Ingress can't setup routing currently.
nginx-ingress-controller has log as follow.
```
W0309 18:15:25.105640       7 controller.go:739] service system/dex-k8s-authenticator does not have any active endpoints
```
Service port set to ingress was the cause, and i fixed it.