### PR TITLE
Explicitly define the CA certificate path

### DIFF
--- a/templates/kubeconfig.html
+++ b/templates/kubeconfig.html
@@ -44,7 +44,7 @@
         <h3>Copy Kubernetes CA Certificate</h3>
 
         <p>Copy this CA Certificate and download it to your .kube directory</p>
-        <pre>curl --create-dirs -s {{ .K8sCaURI }} -o ~/.kube/certs/{{ .ClusterName }}/k8s-ca.crt</pre>
+        <pre>curl --create-dirs -s {{ .K8sCaURI }} -o ${HOME}/.kube/certs/{{ .ClusterName }}/k8s-ca.crt</pre>
         {{ end }}
         
         <h3>Check groups</h3>
@@ -57,7 +57,7 @@
         <p>These commands will update <tt>~/.kube/config</tt></p>
 
         <pre><code>kubectl config set-cluster {{ .ClientID }} \
-  --certificate-authority=certs/{{ .ClusterName}}/k8s-ca.crt \
+  --certificate-authority=${HOME}/.kube/certs/{{ .ClusterName}}/k8s-ca.crt \
   --server={{ .K8sMasterURI }}</code></pre>
 
         <pre><code>kubectl config set-credentials {{ .Username }}-{{ .ClientID }} \


### PR DESCRIPTION
Useful when you want to define another kubecfg.
`export KUBECONFIG=/path/kubecfg`