### PR TITLE
Support pem file as k8s cert

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ type Cluster struct {
 	Client_ID         string
 	K8s_Master_URI    string
 	K8s_Ca_URI        string
+	K8s_Ca_Pem        string
 
 	Verifier       *oidc.IDTokenVerifier
 	Provider       *oidc.Provider

--- a/templates.go
+++ b/templates.go
@@ -27,6 +27,7 @@ type tokenTmplData struct {
 	ClientID         string
 	K8sMasterURI     string
 	K8sCaURI         string
+	K8sCaPem         string
 	IDPCaURI         string
 	LogoURI          string
 }
@@ -62,6 +63,7 @@ func (cluster *Cluster) renderToken(w http.ResponseWriter,
 		ClientID:         cluster.Client_ID,
 		K8sMasterURI:     cluster.K8s_Master_URI,
 		K8sCaURI:         cluster.K8s_Ca_URI,
+		K8sCaPem:         cluster.K8s_Ca_Pem,
 		IDPCaURI:         idpCaURI,
 		LogoURI:          logoURI}
 

--- a/templates/kubeconfig.html
+++ b/templates/kubeconfig.html
@@ -41,10 +41,20 @@
         {{ end }}
 
         {{ if .K8sCaURI }}
-        <h3>Copy Kubernetes CA Certificate</h3>
+        <h3>Copy Kubernetes CA Certificate From URL</h3>
 
         <p>Copy this CA Certificate and download it to your .kube directory</p>
         <pre>curl --create-dirs -s {{ .K8sCaURI }} -o ${HOME}/.kube/certs/{{ .ClusterName }}/k8s-ca.crt</pre>
+        {{ end }}
+
+        {{ if .K8sCaPem }}
+        <h3>Copy Kubernetes CA Certificate From PEM</h3>
+
+        <p>Put the CA Certificate into your .kube directory</p>
+        <pre>mkdir -p ${HOME}/.kube/certs/{{ .ClusterName }}/ || true
+cat &lt;&lt; EOF &gt; ${HOME}/.kube/certs/{{ .ClusterName }}/k8s-ca.crt
+{{ .K8sCaPem }}EOF
+        </pre>
         {{ end }}
         
         <h3>Check groups</h3>


### PR DESCRIPTION
Hi guy,
K8S CA certificate is contained into the cluster and/or stored on nodes filesystem. It is quite tricky to expose an endpoint over http/https to serve the certificate, and it requires a lot of conf. And for example, if I hold it into kube-system namespace near its pk, I do not want to use an http(s) endpoint to serve it thinking I could increase the attack surface.

So I propose to be able to bind the certificate into the config as a string.

```
clusters:
  - name: k8s-cluster
    short_description: "K8S Cluster"
    description: "This is where you generate token to access the cluster..."
    client_secret: ZXhhbXBsZS1hcHAtc2VjcmV0
    issuer:  https://toto:32000
    k8s_master_uri: https://10.30.12.100:6443
    client_id: example-app
    redirect_uri: http://127.0.0.1:5555/callback
    k8s_ca_pem: |
      -----BEGIN CERTIFICATE-----
      MIIdWJlCyDCCAbCgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwpr
      owFTETMBEGAcm5ldGVzMB4XDTE4MDIyMDEzBgkqhkiG9w0BAQsFODEzMTc1MV1UE
      -----END CERTIFICATE-----
```

