### PR TITLE
Provide extra rootca

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-alpine3.7
+FROM golang:1.10.1-alpine3.7
 
 RUN apk add --no-cache --update alpine-sdk bash
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ ! -z "$(ls -A /certs)" ]; then
-  cp /certs/*.crt /usr/local/share/ca-certificates/ 2>/dev/null
+  cp -L /certs/*.crt /certs/*.pem /usr/local/share/ca-certificates/ 2>/dev/null
   update-ca-certificates
 fi
 


### PR DESCRIPTION
Make possible to provide extra trusted root ca (as many you want/need).
It can be useful if your distant dex is presenting a certificate signed with an internal rootca, you will not have any alert on tls negociation between dex-k8s-authenticator and dex...

Example:

```
clusters:
  - name: k8s-cluster
    short_description: "K8S Cluster"
    description: "This is where you generate token to access the cluster..."
    client_secret: ZXhhbXBsZS1hcHAtc2VjcmV0
    issuer:  https://toto:32000
    k8s_master_uri: https://10.30.12.100:6443
    client_id: example-app
    redirect_uri: http://127.0.0.1:5555/callback
listen: http://0.0.0.0:5555
debug: false
trusted_root_ca:
  - |
    -----BEGIN CERTIFICATE-----
    MIIGJDCCBAygAwIBAgIJAPp7Aw5evQcOMA0GCSqGSIb3DQEBCwUAMIGeMQswCQYD
    VQQGEwJGUjEOMAwGA1UECAwFUGFyaXMxDjAMBgNVBAcMBVBhcmlzMQ4wDAYDVQQK
    DAVRd2FudDEeMBwGA1UECwwVUXdhbnQgc2VjdXJpdHkgYWdlbmN5MR8wHQYDVQQD
    -----END CERTIFICATE-----
```