### PR TITLE
Fix missing idp_ca_uri parameter in dex-k8s-authenticator ConfigMap

### DIFF
--- a/charts/dex-k8s-authenticator/templates/configmap.yaml
+++ b/charts/dex-k8s-authenticator/templates/configmap.yaml
@@ -16,6 +16,9 @@ data:
     {{- if .logoUrl }}
     logo_uri: {{ .logoUrl }}
     {{- end }}
+    {{- if .idpCaURI }}
+    idp_ca_uri: {{ .idpCaURI }}
+    {{- end }}
     {{- if and .tlsCert .tlsKey }} 
     tls_cert: "{{ .tlsCert }}"
     tls_key: "{{ .tlsKey }}"


### PR DESCRIPTION
The `dex-k8s-authenticator` Go binary has support for passing an IDentity Provider CA cert URL to the [template render for `linux-mac-common.html`](https://github.com/mintel/dex-k8s-authenticator/blob/master/templates/linux-mac-common.html#L2-L13).  However, the Helm chart was missing this parameter so it was impossible to pass through to the `ConfigMap` containing `config.yaml` for the `Pod`.

This PR fixes the issue by adding parameter `idpCaURI` that conditionally passes through to `idp_ca_uri` in `ConfigMap`.  Tested against `kops` Kubernetes cluster, [Vault PKI backend](https://www.vaultproject.io/docs/secrets/pki/index.html) with Root from `kops` cluster + Intermediate CA chain and [`ca_chain` URI](https://www.vaultproject.io/api/secret/pki/index.html#read-ca-certificate-chain), the Dex chart in this repo with certs generated from cluster root CA via Vault, and finally the certs for `dex-k8s-authenticator` login app also generated via the Vault PKI.

Test Results:

- Without the change in this PR, login flow from `dex-k8s-authenticator => dex => LDAP => dex-k8s-authenticator instructions page` works, but the `kubectl` commands fail with error:

        Unable to connect to the server: x509: certificate signed by unknown authority

- With the change in this PR, full login flow works and includes the instructions for installing IDP CA Cert.  `kubectl` commands then succeed (you no longer get x509 validation errors) so long as appropriate RBAC roles are installed in the cluster.

#### Changes

- `dex-k8s-authenticator`: Add fix to local helm chart ConfigMap template for passing through `idp_ca_uri` parameter. Use camelCase like others