### PR TITLE
Adding tls options for dex via Helm chart

### DIFF
--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+{{- if .Values.tls.create }}
+      - name: tls
+        secret:
+          secretName: {{ template "dex.fullname" $ }}-tls
+{{- end }}
       serviceAccountName: {{ template "dex.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
@@ -63,11 +68,25 @@ spec:
           httpGet:
             path: /healthz
             port: 5556
+          {{- if .Values.tls.create }}
+            scheme: HTTPS
+          {{- end }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+          {{- if .Values.tls.create }}
+            scheme: HTTPS
+          {{- end }}
           initialDelaySeconds: 5
           timeoutSeconds: 1
         volumeMounts:
         - name: config
           mountPath: /etc/dex
+{{- if .Values.tls.create }}
+        - name: tls
+          mountPath: /etc/dex/tls
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}

--- a/charts/dex/templates/secret.yaml
+++ b/charts/dex/templates/secret.yaml
@@ -12,3 +12,20 @@ data:
   {{- range $key, $value := .Values.envSecrets }}
   {{ template "dex.envkey" $key }}: "{{ $value | b64enc }}"
   {{- end }}
+{{- if .Values.tls.create }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "dex.fullname" . }}-tls
+  type: kubernetes.io/tls
+  labels:
+    app: {{ template "dex.fullname" . }}
+    env: {{ default "dev" .Values.global.deployEnv }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+    tls.crt: {{ .Values.tls.certificate | b64enc }}
+    tls.key: {{ .Values.tls.key | b64enc }}
+{{- end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -15,6 +15,26 @@ service:
   type: ClusterIP
   port: 5556
 
+tls:
+  # Specify whether a TLS secret for Dex should be created
+  # The provided certificate and key values are used to populate the
+  # tlsCert and tlsKey values in the Dex configuration.
+  #
+  # If set to true, be sure to update the listen directive in the Dex
+  # configuration to use https.
+  create: false
+
+  # Provide values for certificate and key
+  # certificate: |-
+  #   -----BEGIN CERTIFICATE-----
+  #    ...
+  #    ----END CERTIFICATE-----
+  #
+  # key: |-
+  #   -----BEGIN RSA PRIVATE KEY-----
+  #   ...
+  #   -----END RSA PRIVATE KEY-----
+ 
 ingress:
   enabled: false
   annotations: {}
@@ -71,6 +91,15 @@ config: |-
 
   web:
     http: 0.0.0.0:5556
+
+    # If enabled, be sure to configure tls settings above, or use a tool
+    # such as let-encrypt to manage the certs.
+    # Currently this chart does not support both http and https, and the port
+    # is fixed to 5556
+    #
+    # https: 0.0.0.0:5556
+    # tlsCert: /etc/dex/tls/tls.crt
+    # tlsKey: /etc/dex/tls/tls.key
 
   frontend:
     theme: "coreos"


### PR DESCRIPTION
PR adds TLS support for Dex when using self-signed certs (for use with Helm).

The Helm values are updated to provide:
- `tls.create` to enable the creation of the secrets
- `tls.certificate` for the certificate
- `tls.key` for the private key

The TLS example options are now available in the Helm values (but commented out).

- SSL cert/key installed into `/etc/dex/tls/`
- Port fixed to `5556` (probably ok?)
- Can only configure one of https or http (probably ok?)
- Health probes configured to use https scheme if `tls.create` set