### PR TITLE
Added option for custom readiness/liveness probe path

### DIFF
--- a/charts/dex-k8s-authenticator/templates/_helpers.tpl
+++ b/charts/dex-k8s-authenticator/templates/_helpers.tpl
@@ -30,3 +30,30 @@ Create chart name and version as used by the chart label.
 {{- define "dex-k8s-authenticator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the healthCheckPath for readiness and liveness probes.
+
+Based on the following template values:
+    - healthCheckPath
+    - ingress.path
+    - dexK8sAuthenticator.web_path_prefix
+
+The default is '/healthz'
+*/}}
+
+{{- define "dex-k8s-authenticator.healthCheckPath" -}}
+{{- if .Values.healthCheckPath -}}
+  {{ .Values.healthCheckPath }}
+{{- else -}}
+  {{- if .Values.ingress.enabled -}}
+    {{ default "" .Values.ingress.path | trimSuffix "/" }}/healthz
+  {{- else -}}
+    {{- if .Values.dexK8sAuthenticator.web_path_prefix -}}
+      {{ .Values.dexK8sAuthenticator.web_path_prefix | trimSuffix "/" }}/healthz
+    {{- else -}}
+      {{ "/healthz" }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/dex-k8s-authenticator/templates/deployment.yaml
+++ b/charts/dex-k8s-authenticator/templates/deployment.yaml
@@ -39,11 +39,11 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: {{ .Values.dexK8sAuthenticator.web_path_prefix }}
+            path: {{ template "dex-k8s-authenticator.healthCheckPath" . }}
             port: http
         readinessProbe:
           httpGet:
-            path: {{ .Values.dexK8sAuthenticator.web_path_prefix }}
+            path: {{ template "dex-k8s-authenticator.healthCheckPath" . }}
             port: http
         volumeMounts:
         - name: config

--- a/charts/dex/templates/_helpers.tpl
+++ b/charts/dex/templates/_helpers.tpl
@@ -43,8 +43,34 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Create the health check path
+*/}}
+
+{{/*
 Create secret key from environment variables
 */}}
 {{- define "dex.envkey" -}}
 {{ . | replace "_" "-" | lower }}
+{{- end -}}
+
+{{/*
+Create the healthCheckPath for readiness and liveness probes.
+
+Based on the following template values:
+    - healthCheckPath
+    - ingress.path
+
+The default is '/healthz'
+*/}}
+
+{{- define "dex.healthCheckPath" -}}
+{{- if .Values.healthCheckPath -}}
+  {{ .Values.healthCheckPath }}
+{{- else -}}
+  {{- if .Values.ingress.enabled -}}
+    {{ default "" .Values.ingress.path | trimSuffix "/" }}/healthz
+  {{- else -}}
+    {{ default "/healthz" }}
+  {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -66,14 +66,14 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: {{ template "dex.healthCheckPath" . }}
             port: 5556
           {{- if .Values.tls.create }}
             scheme: HTTPS
           {{- end }}
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: {{ template "dex.healthCheckPath" . }}
             port: 5556
           {{- if .Values.tls.create }}
             scheme: HTTPS


### PR DESCRIPTION
Should resolve #56 

We also introduce an optional `healthCheckPath` helm setting to fully customize this.

If not specified, attempt to set path from `ingress.path`, and also, in the case of `dex-k8s-authenticator`, also the `web_path_prefix`