### PR TITLE
Add safe check for email field

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -59,8 +59,11 @@ func (cluster *Cluster) renderToken(w http.ResponseWriter,
 		panic(err)
 	}
 
-	email := data["email"].(string)
-	unix_username := strings.Split(email, "@")[0]
+	unix_username := "user"
+	if data["email"] != nil {
+		email := data["email"].(string)
+		unix_username = strings.Split(email, "@")[0]
+	}
 
 	token_data := templateData{
 		IDToken:          idToken,


### PR DESCRIPTION
I'm hitting the following error when the email field is not defined (in my case Keycloak+LDAP):

```
http: panic serving 127.0.0.1:55108: interface conversion: interface {} is nil, not string
goroutine 1209 [running]:
net/http.(*conn).serve.func1(0xc4205365a0)
        /usr/local/go/src/net/http/server.go:1697 +0xd0
panic(0x8904e0, 0xc4204d6540)
        /usr/local/go/src/runtime/panic.go:491 +0x283
main.(*Cluster).renderToken(0xc4200ce2c0, 0xb5b180, 0xc420435260, 0xc42024c000, 0x4c9, 0xc42043b680, 0x47a, 0x0, 0x0, 0x0, ...)
        /go/src/github.com/mintel/dex-k8s-authenticator/templates.go:47 +0x4f3
main.(*Cluster).handleCallback(0xc4200ce2c0, 0xb5b180, 0xc420435260, 0xc4203d3700)
        /go/src/github.com/mintel/dex-k8s-authenticator/dex-auth.go:109 +0x976
main.(*Cluster).(main.handleCallback)-fm(0xb5b180, 0xc420435260, 0xc4203d3700)
        /go/src/github.com/mintel/dex-k8s-authenticator/main.go:156 +0x48
net/http.HandlerFunc.ServeHTTP(0xc42040e030, 0xb5b180, 0xc420435260, 0xc4203d3700)
        /usr/local/go/src/net/http/server.go:1918 +0x44
net/http.(*ServeMux).ServeHTTP(0xb9f460, 0xb5b180, 0xc420435260, 0xc4203d3700)
        /usr/local/go/src/net/http/server.go:2254 +0x130
net/http.serverHandler.ServeHTTP(0xc42037c1a0, 0xb5b180, 0xc420435260, 0xc4203d3700)
        /usr/local/go/src/net/http/server.go:2619 +0xb4
net/http.(*conn).serve(0xc4205365a0, 0xb5b9c0, 0xc420506640)
        /usr/local/go/src/net/http/server.go:1801 +0x71d
created by net/http.(*Server).Serve
```

This PR introduce a safe check on the email field, and define a default value if not set.