### PR TITLE
pods will pick configmap changes immediately

### DIFF
--- a/charts/dex-k8s-authenticator/templates/deployment.yaml
+++ b/charts/dex-k8s-authenticator/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
         app: {{ template "dex-k8s-authenticator.name" . }}
         env: {{ default "dev" .Values.global.deployEnv }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
         app: {{ template "dex.name" . }}
         env: {{ default "dev" .Values.global.deployEnv }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       volumes:
       - name: config


### PR DESCRIPTION
When we run helm commands pods are not picking new config immediately, we have to restart/delete pods so that they pick new config on the restart.