### PR TITLE
Add option to avoid usage of username for kube context

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -7,7 +7,7 @@ clusters:
     description: "Example Cluster Long Description..."
 
     # Redirect Url pointing to dex-k8s-authenticator callback for this cluster
-    # This should be configured in Dex as part of the staticClients 
+    # This should be configured in Dex as part of the staticClients
     # redirectURIs option
     redirect_uri: http://127.0.0.1:5555/callback/example-cluster
 
@@ -16,14 +16,14 @@ clusters:
 
     # Client ID - should match value in Dex
     client_id: example-cluster-client-id
-    
+
     # Dex Issuer - Must be resolvable
     issuer:  http://127.0.0.1:5556
 
     # Url to k8s API endpoint - used in WebUI instructions for generating
     # kubeconfig
     k8s_master_uri: https://your-k8s-master.cluster
-    
+
     # CA for your k8s cluster - used in WebUI instructions for generating
     # kubeconfig
     # Both k8s_ca_uri and k8s_ca_pem are optional - you typically specifiy
@@ -36,10 +36,10 @@ clusters:
     # k8s_ca_pem: |
     #   -----BEGIN CERTIFICATE-----
     #   ...
-    #   -----END CERTIFICATE----- 
+    #   -----END CERTIFICATE-----
 
 # Specify multiple extra root CA files to be loaded
-# trusted_root_ca: 
+# trusted_root_ca:
 #   -|
 #     -----BEGIN CERTIFICATE-----
 #     ...
@@ -67,13 +67,13 @@ clusters:
 # Which address to listen on (set to https if tls configured)
 listen: http://127.0.0.1:5555
 
-# A path-prefix from which to serve requests and assets 
+# A path-prefix from which to serve requests and assets
 web_path_prefix: /
 
 # Optional kubectl version which provides a download link to the the binary
 kubectl_version: v1.11.2
 
-# Optional Url to display a logo image 
+# Optional Url to display a logo image
 # logo_uri: http://<path-to-your-logo.png>
 
 # Enable more debug

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -24,6 +24,9 @@ clusters:
     # kubeconfig
     k8s_master_uri: https://your-k8s-master.cluster
 
+    # don't use username for context
+    static_context_name: true
+
     # CA for your k8s cluster - used in WebUI instructions for generating
     # kubeconfig
     # Both k8s_ca_uri and k8s_ca_pem are optional - you typically specifiy

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -25,7 +25,7 @@ clusters:
     k8s_master_uri: https://your-k8s-master.cluster
 
     # don't use username for context
-    static_context_name: true
+    static_context_name: false
 
     # CA for your k8s cluster - used in WebUI instructions for generating
     # kubeconfig

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ type Cluster struct {
 	OfflineAsScope bool
 	Client         *http.Client
 	Redirect_URI   string
-    Config         Config
+	Config         Config
 }
 
 // Define our configuration
@@ -189,7 +189,7 @@ func start_app(config Config) {
 			}()
 		}
 
-        cluster.Config = config
+		cluster.Config = config
 
 		base_redirect_uri, err := url.Parse(cluster.Redirect_URI)
 

--- a/main.go
+++ b/main.go
@@ -55,15 +55,16 @@ func (d debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // Define each cluster
 type Cluster struct {
-	Name              string
-	Short_Description string
-	Description       string
-	Issuer            string
-	Client_Secret     string
-	Client_ID         string
-	K8s_Master_URI    string
-	K8s_Ca_URI        string
-	K8s_Ca_Pem        string
+	Name                string
+	Short_Description   string
+	Description         string
+	Issuer              string
+	Client_Secret       string
+	Client_ID           string
+	K8s_Master_URI      string
+	K8s_Ca_URI          string
+	K8s_Ca_Pem          string
+	Static_Context_Name bool
 
 	Verifier       *oidc.IDTokenVerifier
 	Provider       *oidc.Provider
@@ -75,15 +76,16 @@ type Cluster struct {
 
 // Define our configuration
 type Config struct {
-	Clusters        []Cluster
-	Listen          string
-	Web_Path_Prefix string
-	TLS_Cert        string
-	TLS_Key         string
-	IDP_Ca_URI      string
-	IDP_Ca_Pem      string
-	Logo_Uri        string
-	Trusted_Root_Ca []string
+	Clusters            []Cluster
+	Listen              string
+	Web_Path_Prefix     string
+	TLS_Cert            string
+	TLS_Key             string
+	IDP_Ca_URI          string
+	IDP_Ca_Pem          string
+	Logo_Uri            string
+	Static_Context_Name bool
+	Trusted_Root_Ca     []string
 }
 
 func substituteEnvVars(text string) string {

--- a/templates.go
+++ b/templates.go
@@ -23,24 +23,25 @@ func renderIndex(w http.ResponseWriter, config *Config) {
 }
 
 type templateData struct {
-	IDToken          string
-	RefreshToken     string
-	RedirectURL      string
-	Claims           string
-	Username         string
-	Issuer           string
-	ClusterName      string
-	ShortDescription string
-	ClientSecret     string
-	ClientID         string
-	K8sMasterURI     string
-	K8sCaURI         string
-	K8sCaPem         string
-	IDPCaURI         string
-	IDPCaPem         string
-	LogoURI          string
-	Web_Path_Prefix  string
-	KubectlVersion   string
+	IDToken           string
+	RefreshToken      string
+	RedirectURL       string
+	Claims            string
+	Username          string
+	Issuer            string
+	ClusterName       string
+	ShortDescription  string
+	ClientSecret      string
+	ClientID          string
+	K8sMasterURI      string
+	K8sCaURI          string
+	K8sCaPem          string
+	IDPCaURI          string
+	IDPCaPem          string
+	LogoURI           string
+	Web_Path_Prefix   string
+	StaticContextName bool
+	KubectlVersion    string
 }
 
 func (cluster *Cluster) renderToken(w http.ResponseWriter,
@@ -66,24 +67,25 @@ func (cluster *Cluster) renderToken(w http.ResponseWriter,
 	}
 
 	token_data := templateData{
-		IDToken:          idToken,
-		RefreshToken:     refreshToken,
-		RedirectURL:      cluster.Redirect_URI,
-		Claims:           string(claims),
-		Username:         unix_username,
-		Issuer:           data["iss"].(string),
-		ClusterName:      cluster.Name,
-		ShortDescription: cluster.Short_Description,
-		ClientSecret:     cluster.Client_Secret,
-		ClientID:         cluster.Client_ID,
-		K8sMasterURI:     cluster.K8s_Master_URI,
-		K8sCaURI:         cluster.K8s_Ca_URI,
-		K8sCaPem:         cluster.K8s_Ca_Pem,
-		IDPCaURI:         idpCaURI,
-		IDPCaPem:         idpCaPem,
-		LogoURI:          logoURI,
-		Web_Path_Prefix:  webPathPrefix,
-		KubectlVersion:   kubectlVersion}
+		IDToken:           idToken,
+		RefreshToken:      refreshToken,
+		RedirectURL:       cluster.Redirect_URI,
+		Claims:            string(claims),
+		Username:          unix_username,
+		Issuer:            data["iss"].(string),
+		ClusterName:       cluster.Name,
+		ShortDescription:  cluster.Short_Description,
+		ClientSecret:      cluster.Client_Secret,
+		ClientID:          cluster.Client_ID,
+		K8sMasterURI:      cluster.K8s_Master_URI,
+		K8sCaURI:          cluster.K8s_Ca_URI,
+		K8sCaPem:          cluster.K8s_Ca_Pem,
+		IDPCaURI:          idpCaURI,
+		IDPCaPem:          idpCaPem,
+		LogoURI:           logoURI,
+		Web_Path_Prefix:   webPathPrefix,
+		StaticContextName: cluster.Static_Context_Name,
+		KubectlVersion:    kubectlVersion}
 
 	err = templates.ExecuteTemplate(w, "kubeconfig.html", token_data)
 

--- a/templates/linux-mac-common.html
+++ b/templates/linux-mac-common.html
@@ -94,7 +94,7 @@ EOF</code></pre>
     <button class="btn" style="float:right" data-clipboard-snippet="">
       <img class="clippy" width="13" src="{{ .Web_Path_Prefix }}static/clippy.svg" alt="">
     </button>
-    <pre><code class="hljs">kubectl config set-context {{ .Username }}-{{ .ClusterName }} \
+    <pre><code class="hljs">kubectl config set-context {{ if not .StaticContextName }}{{ .Username }}-{{ end }}{{ .ClusterName }} \
     --cluster={{ .ClusterName }} \
     --user={{ .Username}}-{{.ClusterName }}</code></pre>
   </div>
@@ -104,7 +104,7 @@ EOF</code></pre>
     <button class="btn" style="float:right" data-clipboard-snippet="">
       <img class="clippy" width="13" src="{{ .Web_Path_Prefix }}static/clippy.svg" alt=""/>
     </button>
-    <pre><code class="hljs">kubectl config use-context {{ .Username }}-{{ .ClusterName}}</code></pre>
+    <pre><code class="hljs">kubectl config use-context {{ if not .StaticContextName }}{{ .Username }}-{{ end }}{{ .ClusterName}}</code></pre>
   </div>
 
 {{ end }}

--- a/templates/windows-tab.html
+++ b/templates/windows-tab.html
@@ -102,14 +102,14 @@ EOF</code></pre>
     <button class="btn" style="float:right" data-clipboard-snippet="">
       <img class="clippy" width="13" src="{{ .Web_Path_Prefix }}static/clippy.svg" alt="">
     </button>
-    <pre><code class="hljs">kubectl config set-context {{ .Username }}-{{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Username}}-{{.ClusterName }}</code></pre>
+    <pre><code class="hljs">kubectl config set-context {{ if not .StaticContextName }}{{ .Username }}-{{ end }}{{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Username}}-{{.ClusterName }}</code></pre>
   </div>
 
   <div class="command">
     <button class="btn" style="float:right" data-clipboard-snippet="">
       <img class="clippy" width="13" src="{{ .Web_Path_Prefix }}static/clippy.svg" alt=""/>
     </button>
-    <pre><code class="hljs">kubectl config use-context {{ .Username }}-{{ .ClusterName}}</code></pre>
+    <pre><code class="hljs">kubectl config use-context {{ if not .StaticContextName }}{{ .Username }}-{{ end }}{{ .ClusterName}}</code></pre>
   </div>
 
 {{ end }}


### PR DESCRIPTION
This PR adds an optional cluster config `static_context_name: true` which avoids the usage of the username for the context in templates like `{{ .Username }}-{{ .ClusterName }}`

We do need this option to unify the context name on workstations.