### PR TITLE
Fix idp ca field in the helm chart

### DIFF
--- a/charts/dex-k8s-authenticator/templates/configmap.yaml
+++ b/charts/dex-k8s-authenticator/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
     idp_ca_uri: {{ .idpCaURI }}
     {{- end }}
     {{- if .idpCaPem }}
-    idp_ca_pem: {{ .idpCaPem }}
+    idp_ca_pem: {{ toYaml .idpCaPem | indent 4 }}
     {{- end }}
     {{- if and .tlsCert .tlsKey }} 
     tls_cert: "{{ .tlsCert }}"


### PR DESCRIPTION
idp ca field in the helm chart is useless as is. If you specify it with a multiline ca pem file, the chart won't install complaining about configmap.yaml validation issue. This PR fixes it.