### PR TITLE
Helm chart: pin docker tag: 1.1.0

### DIFF
--- a/charts/dex-k8s-authenticator/values.yaml
+++ b/charts/dex-k8s-authenticator/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: mintel/dex-k8s-authenticator
-  tag: latest
+  tag: 1.1.0
   pullPolicy: Always
 
 dexK8sAuthenticator:


### PR DESCRIPTION
Do not use latest, as it may break existing releases in the future.