### PR TITLE
Support loading IDP_CA_PEM and TRUSTED_ROOT_CA from file

### DIFF
--- a/dex-auth.go
+++ b/dex-auth.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/coreos/go-oidc"
-	"github.com/spf13/viper"
 	"github.com/spf13/cast"
+	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 	"io/ioutil"
 	"log"
@@ -50,8 +50,8 @@ func (cluster *Cluster) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 func (cluster *Cluster) handleCallback(w http.ResponseWriter, r *http.Request) {
 	var (
-		err   error
-		token *oauth2.Token
+		err      error
+		token    *oauth2.Token
 		IdpCaPem string
 	)
 

--- a/dex-auth.go
+++ b/dex-auth.go
@@ -52,7 +52,7 @@ func (cluster *Cluster) handleCallback(w http.ResponseWriter, r *http.Request) {
 	var (
 		err   error
 		token *oauth2.Token
-		IDP_CA_PEM string
+		IdpCaPem string
 	)
 
 	log.Printf("Handling callback for: %s", cluster.Name)
@@ -116,18 +116,18 @@ func (cluster *Cluster) handleCallback(w http.ResponseWriter, r *http.Request) {
 	json.Indent(buff, []byte(claims), "", "  ")
 
 	if cluster.Config.IDP_Ca_Pem != "" {
-		IDP_CA_PEM = cluster.Config.IDP_Ca_Pem
+		IdpCaPem = cluster.Config.IDP_Ca_Pem
 	} else if cluster.Config.IDP_Ca_Pem_File != "" {
 		content, err := ioutil.ReadFile(cluster.Config.IDP_Ca_Pem_File)
 		if err != nil {
 			log.Fatalf("Failed to load CA from file %s, %s", cluster.Config.IDP_Ca_Pem_File, err)
 		}
-		IDP_CA_PEM = cast.ToString(content)
+		IdpCaPem = cast.ToString(content)
 	}
 
 	cluster.renderToken(w, rawIDToken, token.RefreshToken,
 		cluster.Config.IDP_Ca_URI,
-		IDP_CA_PEM,
+		IdpCaPem,
 		cluster.Config.Logo_Uri,
 		cluster.Config.Web_Path_Prefix,
 		viper.GetString("kubectl_version"),

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,28 +5,30 @@ An example configuration is available [here](../examples/config.yaml)
 ## Configuration options
 
 
-| Name              | Required | Context | Description                                                                           |
-|-------------------|----------|---------|---------------------------------------------------------------------------------------|
-| name              | yes      | cluster | Internal id of cluster                                                                |
-| short_description | yes      | cluster | Short description of cluster                                                          |
-| description       | yes      | cluster | Extended description of cluster                                                       |
-| client_secret     | yes      | cluster | OAuth2 client-secret (shared between dex-k8s-auth and dex)                            |
-| client_id         | yes      | cluster | OAuth2 client-id public identifier (shared between dex-k8s-auth and dex)              |
-| issuer            | yes      | cluster | Dex issuer url                                                                        |
-| redirect_uri      | yes      | cluster | Redirect uri called by dex (defines a callback on dex-k8s-auth)                       |
-| k8s_master_uri    | no       | cluster | Kubernetes api-server endpoint (used in kubeconfig)                                   |
-| k8s_ca_uri        | no       | cluster | A url pointing to the CA for generating 'certificate-authority' option in kubeconfig  |
-| k8s_ca_pem        | no       | cluster | The CA for your k8s server (used in generating instructions)                          |
-| tls_cert          | no       | root    | Path to TLS cert if SSL enabled                                                       |
-| tls_key           | no       | root    | Path to TLS key if SSL enabled                                                        |
-| idp_ca_uri        | no       | root    | A url pointing to the CA for generating 'idp-certificate-authority' in the kubeconfig |
-| idp_ca_pem        | no       | root    | The CA for generating 'idp-certificate-authority' in the kubeconfig                   |
-| trusted_root_ca   | no       | root    | A list of trusted-root CA's to be loaded by dex-k8s-auth at runtime                   |
-| listen            | yes      | root    | The listen address/port                                                               |
-| web_path_prefix   | no       | root    | A path-prefix to serve dex-k8s-auth at (defaults to '/')                              |
-| kubectl_version   | no       | root    | A kubectl-version string that is used to provided a download path                     |
-| logo_uri          | no       | root    | A url pointing to a logo image that is displayed in the header                        |
-| debug             | no       | root    | Enable more debug by setting to true                                                  |
+| Name                   | Required | Context | Description                                                                           |
+|------------------------|----------|---------|---------------------------------------------------------------------------------------|
+| name                   | yes      | cluster | Internal id of cluster                                                                |
+| short_description      | yes      | cluster | Short description of cluster                                                          |
+| description            | yes      | cluster | Extended description of cluster                                                       |
+| client_secret          | yes      | cluster | OAuth2 client-secret (shared between dex-k8s-auth and dex)                            |
+| client_id              | yes      | cluster | OAuth2 client-id public identifier (shared between dex-k8s-auth and dex)              |
+| issuer                 | yes      | cluster | Dex issuer url                                                                        |
+| redirect_uri           | yes      | cluster | Redirect uri called by dex (defines a callback on dex-k8s-auth)                       |
+| k8s_master_uri         | no       | cluster | Kubernetes api-server endpoint (used in kubeconfig)                                   |
+| k8s_ca_uri             | no       | cluster | A url pointing to the CA for generating 'certificate-authority' option in kubeconfig  |
+| k8s_ca_pem             | no       | cluster | The CA for your k8s server (used in generating instructions)                          |
+| tls_cert               | no       | root    | Path to TLS cert if SSL enabled                                                       |
+| tls_key                | no       | root    | Path to TLS key if SSL enabled                                                        |
+| idp_ca_uri             | no       | root    | A url pointing to the CA for generating 'idp-certificate-authority' in the kubeconfig |
+| idp_ca_pem             | no       | root    | The CA for generating 'idp-certificate-authority' in the kubeconfig                   |
+| idp_ca_pem_file        | no       | root    | The CA for generating 'idp-certificate-authority' in the kubeconfig - load from file  |
+| trusted_root_ca        | no       | root    | A list of trusted-root CA's to be loaded by dex-k8s-auth at runtime                   |
+| trusted_root_ca_file   | no       | root    | A list of trusted-root CA's to be loaded by dex-k8s-auth at runtime - load from file  |
+| listen                 | yes      | root    | The listen address/port                                                               |
+| web_path_prefix        | no       | root    | A path-prefix to serve dex-k8s-auth at (defaults to '/')                              |
+| kubectl_version        | no       | root    | A kubectl-version string that is used to provided a download path                     |
+| logo_uri               | no       | root    | A url pointing to a logo image that is displayed in the header                        |
+| debug                  | no       | root    | Enable more debug by setting to true                                                  |
 
 ## Environment Variable Support
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ type Config struct {
 	TLS_Key              string
 	IDP_Ca_URI           string
 	IDP_Ca_Pem           string
-	IDP_Ca_Pem_file      string
+	IDP_Ca_Pem_File      string
 	Logo_Uri             string
 	Static_Context_Name  bool
 	Trusted_Root_Ca      []string

--- a/main.go
+++ b/main.go
@@ -76,16 +76,18 @@ type Cluster struct {
 
 // Define our configuration
 type Config struct {
-	Clusters            []Cluster
-	Listen              string
-	Web_Path_Prefix     string
-	TLS_Cert            string
-	TLS_Key             string
-	IDP_Ca_URI          string
-	IDP_Ca_Pem          string
-	Logo_Uri            string
-	Static_Context_Name bool
-	Trusted_Root_Ca     []string
+	Clusters             []Cluster
+	Listen               string
+	Web_Path_Prefix      string
+	TLS_Cert             string
+	TLS_Key              string
+	IDP_Ca_URI           string
+	IDP_Ca_Pem           string
+	IDP_Ca_Pem_file      string
+	Logo_Uri             string
+	Static_Context_Name  bool
+	Trusted_Root_Ca      []string
+	Trusted_Root_Ca_File string
 }
 
 func substituteEnvVars(text string) string {
@@ -115,10 +117,24 @@ func start_app(config Config) {
 	}
 
 	certp, err := x509.SystemCertPool()
-	for _, cert := range config.Trusted_Root_Ca {
-		ok := certp.AppendCertsFromPEM([]byte(cert))
+	// Load Inline CA certs
+	if len(config.Trusted_Root_Ca) > 0 {
+		for _, cert := range config.Trusted_Root_Ca {
+			ok := certp.AppendCertsFromPEM([]byte(cert))
+			if !ok {
+				log.Fatalf("Failed to parse a trusted cert, pem format expected")
+			}
+		}
+	}
+	// Load CA certs from file
+	if config.Trusted_Root_Ca_File != "" {
+		content, err := ioutil.ReadFile(config.Trusted_Root_Ca_File)
+		if err != nil {
+			log.Fatalf("Failed to read file Trusted Root CA %s", config.Trusted_Root_Ca_File)
+		}
+		ok := certp.AppendCertsFromPEM([]byte(content))
 		if !ok {
-			log.Fatalf("Failed to parse a trusted cert, pem format expected")
+			log.Fatalf("Failed to parse a trusted cert from file %s, pem format expected", config.Trusted_Root_Ca_File)
 		}
 	}
 


### PR DESCRIPTION
This is very useful if SSL assets for dex-k8s-authenticator are cread with [cert-manager](https://docs.cert-manager.io/en/latest/reference/certificates.html#certificate-duration-and-renewal-window) or a similar tool that will create a secret dynamically

