### PR TITLE
Added tab to display only the id-token

### DIFF
--- a/templates/id-token-tab.html
+++ b/templates/id-token-tab.html
@@ -1,0 +1,11 @@
+{{ define "id-token-content" }}
+
+<p>The ID Token signed by dex and returned as part of the OAuth2 response - represented as a Json Web Token (JWT).</p>
+
+<div class="command">
+  <button class="btn" style="float:right" data-clipboard-snippet="">
+    <img class="clippy" width="13" src="{{ .Web_Path_Prefix }}static/clippy.svg" alt=""/>
+  </button>
+  <pre><code>{{ .IDToken }}</pre></code>
+</div>  
+{{ end }}

--- a/templates/kubeconfig.html
+++ b/templates/kubeconfig.html
@@ -44,6 +44,7 @@
           <button class="tablinks active" onclick="openTab(event, 'Linux')">Linux</button>
           <button class="tablinks" onclick="openTab(event, 'MacOS')">MacOS</button>
           <button class="tablinks" onclick="openTab(event, 'Windows')">Windows</button>
+          <button class="tablinks" onclick="openTab(event, 'IDToken')">ID Token</button>
         </div>
 
         <div id="Linux" class="tabcontent" style="display: block">
@@ -57,6 +58,11 @@
         <div id="Windows" class="tabcontent">
           {{ template "windows-tab-content" . }}
         </div>
+
+        <div id="IDToken" class="tabcontent">
+          {{ template "id-token-content" . }}
+        </div>
+
     </div>
   </div>
 


### PR DESCRIPTION
@fciocchetti does this look alright?

If the wording makes sense, I'll update the screenshot in the main readme and we can merge it in.

I would like to add some blurb about how the token could be used by other services too, but nothing too specific.

<img width="1093" alt="Screenshot 2019-07-18 at 19 08 03" src="https://user-images.githubusercontent.com/28828562/61481449-36209300-a990-11e9-859f-f99e414cd94c.png">

*note, it's a fake token ;)