### PR TITLE
Propagate SIGTERM for graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.10.1
 # experience when this doesn't work out of the box.
 #
 # OpenSSL is required so wget can query HTTPS endpoints for health checking.
-RUN apk add --update ca-certificates openssl curl
+RUN apk add --update ca-certificates openssl curl tini
 
 RUN mkdir -p /app/bin
 COPY --from=0 /app/bin/dex-k8s-authenticator /app/bin/
@@ -38,7 +38,7 @@ WORKDIR /app
 COPY entrypoint.sh /
 RUN chmod a+x /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 
 CMD ["--help"]
 


### PR DESCRIPTION
If the process receiving the signal is PID 1, it gets special treatment
by the kernel; if it hasn't registered a handler for the signal, the
kernel won't fall back to default behavior, and nothing happens. Prior
to this patch, the entrypoint script is PID 1 in the container, and by
default, shell does not register SIGTERM handler. As a result, `docker
stop` will not work properly when trying to gracefully shutdown the
container.
    
This patch adds `tini` to be the PID 1 in the container to do PID 1
things, and correctly propagate the SIGTERM signal.