### PR TITLE
Fix dex affinity indentation

### DIFF
--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 6 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
currently indentation is off
```diff
+       affinity:
+       nodeAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           nodeSelectorTerms:
```
that leads to
```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.spec): unknown field "nodeAffinity" in io.k8s.api.core.v1.PodSpec
```