### PR TITLE
Pin helm to 2.x (for now) and kubeval in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
   # Run helm lint checks
   helm_lint:
     docker:
-      - image: lachlanevenson/k8s-helm
+      - image: lachlanevenson/k8s-helm:v2.16.1
     steps:
       - checkout
       - run:
@@ -61,7 +61,7 @@ jobs:
   # Run Kubernetes lint checks
   k8s_lint:
     docker:
-      - image: garethr/kubeval
+      - image: garethr/kubeval:0.14.0
     steps:
       - attach_workspace:
           at: /tmp/charts

--- a/charts/dex/out.yaml
+++ b/charts/dex/out.yaml
@@ -1,0 +1,381 @@
+---
+# Source: dex/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: RELEASE-NAME-dex
+  labels:
+    app: RELEASE-NAME-dex
+    env: dev
+    chart: "dex-1.2.0"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+data:
+  github-client-id: "b3ZlcnJpZGUtbWU="
+  github-client-secret: "b3ZlcnJpZGUtbWU="
+  google-client-id: "b3ZlcnJpZGUtbWU="
+  google-client-secret: "b3ZlcnJpZGUtbWU="
+  ldap-bindpw: "b3ZlcnJpZGUtbWU="
+  microsoft-application-id: "b3ZlcnJpZGUtbWU="
+  microsoft-client-secret: "b3ZlcnJpZGUtbWU="
+---
+# Source: dex/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: RELEASE-NAME-dex
+  labels:
+    app: RELEASE-NAME-dex
+    env: dev
+    chart: "dex-1.2.0"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+data:
+  config.yaml: |-
+    issuer: https://dex.example.com
+    
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+    
+    web:
+      http: 0.0.0.0:5556
+    
+      # If enabled, be sure to configure tls settings above, or use a tool
+      # such as let-encrypt to manage the certs.
+      # Currently this chart does not support both http and https, and the port
+      # is fixed to 5556
+      #
+      # https: 0.0.0.0:5556
+      # tlsCert: /etc/dex/tls/tls.crt
+      # tlsKey: /etc/dex/tls/tls.key
+    
+    frontend:
+      theme: "coreos"
+      issuer: "Example Co"
+      issuerUrl: "https://example.com"
+      logoUrl: https://example.com/images/logo-250x25.png
+    
+    expiry:
+      signingKeys: "6h"
+      idTokens: "24h"
+    
+    logger:
+      level: debug
+      format: json
+    
+    oauth2:
+      responseTypes: ["code", "token", "id_token"]
+      skipApprovalScreen: true
+    
+    # Remember you can have multiple connectors of the same 'type' (with different 'id's)
+    # If you need e.g. logins with groups for two different Microsoft 'tenants'
+    connectors:
+    
+    # GitHub configure 'OAuth Apps' -> 'New OAuth App', add callback URL
+    # https://github.com/settings/developers
+    - type: github
+      id: github
+      name: GitHub
+      config:
+        clientID: $GITHUB_CLIENT_ID
+        clientSecret: $GITHUB_CLIENT_SECRET
+        redirectURI: https://dex.example.com/callback
+        # 'orgs' can be used to map groups from Github
+        # https://github.com/coreos/dex/blob/master/Documentation/connectors/github.md
+        #orgs:
+        #- name: foo
+        #  teams:
+        #  - team-red
+        #  - team-blue
+        #- name: bar
+    
+    # Google APIs account, 'Create Credentials' -> 'OAuth Client ID', add callback URL
+    # https://console.developers.google.com/apis/credentials
+    - type: oidc
+      id: google
+      name: Google
+      config:
+        issuer: https://accounts.google.com
+        clientID: $GOOGLE_CLIENT_ID
+        clientSecret: $GOOGLE_CLIENT_SECRET
+        redirectURI: https://dex.example.com/callback
+        # Google supports whitelisting allowed domains when using G Suite
+        # (Google Apps). The following field can be set to a list of domains
+        # that can log in:
+        # hostedDomains:
+        #  - example.com
+        #  - other.example.com
+    
+    # Microsoft App Dev account, 'Add an app'
+    # 'Application Secrets' -> 'Generate new password'
+    # 'Platforms' -> 'Add Platform' -> 'Web', add the callback URL
+    # https://apps.dev.microsoft.com/
+    - type: microsoft
+      id: microsoft
+      name: Microsoft
+      config:
+        clientID: $MICROSOFT_APPLICATION_ID
+        clientSecret: $MICROSOFT_CLIENT_SECRET
+        redirectURI: https://dex.example.com/callback
+        # Restrict access to one tenant
+        # tenant: <tenant name> or <tenant uuid>
+        # Restrict access to certain groups
+        # groups:
+        # - group-red
+        # - group-blue
+    
+    # These may not match the schema used by your LDAP server
+    # https://github.com/coreos/dex/blob/master/Documentation/connectors/ldap.md
+    - type: ldap
+      id: ldap
+      name: "LDAP"
+      config:
+        host: ldap.example.com:389
+        startTLS: true
+        bindDN: "cn=serviceAccount,dc=example,dc=com"
+        bindPW: $LDAP_BINDPW
+        usernamePrompt: "Username"
+        userSearch:
+          # Query should be "(&(objectClass=inetorgperson)(cn=<username>))"
+          baseDN: "ou=Users,dc=example,dc=com"
+          filter: "(objectClass=inetorgperson)"
+          username: cn
+          # DN must be in capitals
+          idAttr: DN
+          emailAttr: mail
+          nameAttr: displayName
+        groupSearch:
+          # Query should be "(&(objectClass=groupOfUniqueNames)(uniqueMember=<userAttr>))"
+          baseDN: "ou=Groups,dc=example,dc=com"
+          filter: "(objectClass=groupOfUniqueNames)"
+          # DN must be in capitals
+          userAttr: DN
+          groupAttr: uniqueMember
+          nameAttr: cn
+    
+    # The 'name' must match the k8s API server's 'oidc-client-id'
+    staticClients:
+    - id: my-cluster
+      name: "my-cluster"
+      secret: "pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok"
+      redirectURIs:
+      - https://login.example.com/callback/my-cluster
+    
+    enablePasswordDB: True
+    staticPasswords:
+    - email: "admin@example.com"
+      # bcrypt hash of the string "password"
+      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+      username: "admin"
+      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+---
+# Source: dex/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: RELEASE-NAME-dex
+  labels:
+    app: RELEASE-NAME-dex
+    env: dev
+    chart: dex-1.2.0
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+---
+# Source: dex/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: RELEASE-NAME-dex
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+---
+# Source: dex/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: RELEASE-NAME-dex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: RELEASE-NAME-dex
+subjects:
+- kind: ServiceAccount
+  name: RELEASE-NAME-dex
+  namespace: default
+---
+# Source: dex/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: RELEASE-NAME-dex
+  namespace: default
+rules:
+- apiGroups:
+  - dex.coreos.com
+  resources:
+  - authcodes
+  - authrequests
+  - connectors
+  - oauth2clients
+  - offlinesessionses
+  - passwords
+  - refreshtokens
+  - signingkeies
+  verbs:
+  - "*"
+---
+# Source: dex/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: RELEASE-NAME-dex
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: RELEASE-NAME-dex
+subjects:
+- kind: ServiceAccount
+  name: RELEASE-NAME-dex
+  namespace: default
+---
+# Source: dex/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-dex
+  labels:
+    app: dex
+    env: dev
+    chart: dex-1.2.0
+    release: RELEASE-NAME
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5556
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: dex
+    release: RELEASE-NAME
+---
+# Source: dex/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-dex
+  labels:
+    app: dex
+    env: dev
+    chart: dex-1.2.0
+    release: RELEASE-NAME
+    heritage: Helm
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  replicas: 1
+  minReadySeconds: 30
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: dex
+      env: dev
+      release: RELEASE-NAME
+  template:
+    metadata:
+      labels:
+        app: dex
+        env: dev
+        release: RELEASE-NAME
+      annotations:
+        checksum/config: 75e5b0ab554add775d04b76986ecc566a427de421356173114efa0c05db92520
+    spec:
+      volumes:
+      - name: config
+        configMap:
+          name: RELEASE-NAME-dex
+          items:
+          - key: config.yaml
+            path: config.yaml
+      serviceAccountName: RELEASE-NAME-dex
+      containers:
+      - name: dex
+        image: "quay.io/dexidp/dex:v2.20.0"
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/dex", "serve", "/etc/dex/config.yaml"]
+        env:
+        - name: GITHUB_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: RELEASE-NAME-dex
+              key: github-client-id
+        - name: GITHUB_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: RELEASE-NAME-dex
+              key: github-client-secret
+        - name: GOOGLE_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: RELEASE-NAME-dex
+              key: google-client-id
+        - name: GOOGLE_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: RELEASE-NAME-dex
+              key: google-client-secret
+        - name: LDAP_BINDPW
+          valueFrom:
+            secretKeyRef:
+              name: RELEASE-NAME-dex
+              key: ldap-bindpw
+        - name: MICROSOFT_APPLICATION_ID
+          valueFrom:
+            secretKeyRef:
+              name: RELEASE-NAME-dex
+              key: microsoft-application-id
+        - name: MICROSOFT_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: RELEASE-NAME-dex
+              key: microsoft-client-secret
+        ports:
+        - name: http
+          containerPort: 5556
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: config
+          mountPath: /etc/dex
+        resources:
+          {}
+      affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/e2e-az-name
+              operator: In
+              values:
+              - e2e-az1
+              - e2e-az2


### PR DESCRIPTION
Was using upstream `latest` of helm, which of course now is now helm v3.

Various options are no longer available - we'll bump to v3 oneday, but right now stick with v2 in CI.