### PR TITLE
Add namespace field to cluster config

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,6 +2,9 @@ clusters:
   # Specify 1 or more clusters
   - name: example-cluster
 
+    # Default namespace (optional)
+    namespace: my-namespace
+
     # Descriptions used in the WebUI
     short_description: "Example Cluster"
     description: "Example Cluster Long Description..."

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func (d debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // Define each cluster
 type Cluster struct {
 	Name                string
+	Namespace           string
 	Short_Description   string
 	Description         string
 	Issuer              string

--- a/templates.go
+++ b/templates.go
@@ -43,6 +43,7 @@ type templateData struct {
 	Web_Path_Prefix   string
 	StaticContextName bool
 	KubectlVersion    string
+	Namespace         string
 }
 
 func (cluster *Cluster) renderToken(w http.ResponseWriter,
@@ -86,6 +87,7 @@ func (cluster *Cluster) renderToken(w http.ResponseWriter,
 		LogoURI:           logoURI,
 		Web_Path_Prefix:   webPathPrefix,
 		StaticContextName: cluster.Static_Context_Name,
+		Namespace:         cluster.Namespace,
 		KubectlVersion:    kubectlVersion}
 
 	err = templates.ExecuteTemplate(w, "kubeconfig.html", token_data)

--- a/templates/linux-mac-common.html
+++ b/templates/linux-mac-common.html
@@ -97,7 +97,7 @@ EOF</code></pre>
       <img class="clippy" width="13" src="{{ .Web_Path_Prefix }}static/clippy.svg" alt="">
     </button>
     <pre><code class="hljs">kubectl config set-context {{ if not .StaticContextName }}{{ .Username }}-{{ end }}{{ .ClusterName }} \
-    --cluster={{ .ClusterName }} \
+    --cluster={{ .ClusterName }}{{ if .Namespace }} --namespace={{ .Namespace }}{{ end }} \
     --user={{ .Username}}-{{.ClusterName }}</code></pre>
   </div>
 


### PR DESCRIPTION
This PR adds support for setting a default namespace which is included in the `set-context` part of the instructions.