### PR TITLE
Allow specifying OIDC scopes per cluster

### DIFF
--- a/dex-auth.go
+++ b/dex-auth.go
@@ -17,13 +17,13 @@ import (
 
 const exampleAppState = "Vgn2lp5QnymFtLntKX5dM8k773PwcM87T4hQtiESC1q8wkUBgw5D3kH0r5qJ"
 
-func (cluster *Cluster) oauth2Config(scopes []string) *oauth2.Config {
+func (cluster *Cluster) oauth2Config() *oauth2.Config {
 
 	return &oauth2.Config{
 		ClientID:     cluster.Client_ID,
 		ClientSecret: cluster.Client_Secret,
 		Endpoint:     cluster.Provider.Endpoint(),
-		Scopes:       scopes,
+		Scopes:       cluster.Scopes,
 		RedirectURL:  cluster.Redirect_URI,
 	}
 }
@@ -38,12 +38,8 @@ func (config *Config) handleIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (cluster *Cluster) handleLogin(w http.ResponseWriter, r *http.Request) {
-	var scopes []string
-
-	scopes = append(scopes, "openid", "profile", "email", "offline_access", "groups")
-
 	log.Printf("Handling login-uri for: %s", cluster.Name)
-	authCodeURL := cluster.oauth2Config(scopes).AuthCodeURL(exampleAppState, oauth2.AccessTypeOffline)
+	authCodeURL := cluster.oauth2Config().AuthCodeURL(exampleAppState, oauth2.AccessTypeOffline)
 	log.Printf("Redirecting post-loginto: %s", authCodeURL)
 	http.Redirect(w, r, authCodeURL, http.StatusSeeOther)
 }
@@ -61,7 +57,7 @@ func (cluster *Cluster) handleCallback(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Handling callback for: %s", cluster.Name)
 
 	ctx := oidc.ClientContext(r.Context(), cluster.Client)
-	oauth2Config := cluster.oauth2Config(nil)
+	oauth2Config := cluster.oauth2Config()
 	switch r.Method {
 	case "GET":
 		// Authorization redirect callback from OAuth2 auth flow.

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,7 @@ An example configuration is available [here](../examples/config.yaml)
 | k8s_master_uri         | no       | cluster | Kubernetes api-server endpoint (used in kubeconfig)                                   |
 | k8s_ca_uri             | no       | cluster | A url pointing to the CA for generating 'certificate-authority' option in kubeconfig  |
 | k8s_ca_pem             | no       | cluster | The CA for your k8s server (used in generating instructions)                          |
+| scopes                 | no       | cluster | A list OpenID scopes to request                                                       |
 | tls_cert               | no       | root    | Path to TLS cert if SSL enabled                                                       |
 | tls_key                | no       | root    | Path to TLS key if SSL enabled                                                        |
 | idp_ca_uri             | no       | root    | A url pointing to the CA for generating 'idp-certificate-authority' in the kubeconfig |
@@ -61,6 +62,10 @@ clusters:
     client_id: example-cluster-client-id
     issuer:  http://127.0.0.1:5556
     k8s_master_uri: https://your-k8s-master.cluster
+    scopes: 
+      - email
+      - profile
+      - openid
 
 # A path-prefix from which to serve requests and assets
 web_path_prefix: /dex-auth

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ type Cluster struct {
 	K8s_Ca_URI          string
 	K8s_Ca_Pem          string
 	Static_Context_Name bool
+	Scopes              []string
 
 	Verifier       *oidc.IDTokenVerifier
 	Provider       *oidc.Provider
@@ -213,6 +214,10 @@ func start_app(config Config) {
 				}
 				return false
 			}()
+		}
+
+		if len(cluster.Scopes) == 0 {
+			cluster.Scopes = []string{"openid", "profile", "email", "offline_access", "groups"}
 		}
 
 		cluster.Config = config


### PR DESCRIPTION
We wanted to use this with AWS Cognito, but the default scopes aren't compatible with Cognito User Pool OIDC settings (without a custom resource server). 

With configurable scopes, we were able to use Cognito as an OIDC provider in place of Dex. 

I know that technically this tool is designed for Dex...but this removes that restriction to a particular idP while preserving existing functionality.