### PR TITLE
Add option to organize clusters by group.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -66,6 +66,7 @@ clusters:
       - email
       - profile
       - openid
+    group: dev
 
 # A path-prefix from which to serve requests and assets
 web_path_prefix: /dex-auth

--- a/html/static/main.css
+++ b/html/static/main.css
@@ -16,11 +16,16 @@ pre {
   overflow-wrap: break-word;
 }
 
+.groups-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 1em;
+  grid-auto-rows: 1fr;
+}
+
 .dex-container {
   color: #333;
   margin: 45px auto;
-  max-width: 500px;
-  min-width: 320px;
   text-align: center;
 }
 
@@ -28,7 +33,6 @@ pre {
   color: #333;
   margin: 45px auto;
   max-width: 90%;
-  min-width: 320px;
   text-align: left;
 }
 

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ type Cluster struct {
 	K8s_Ca_Pem          string
 	Static_Context_Name bool
 	Scopes              []string
+	Group               string
 
 	Verifier       *oidc.IDTokenVerifier
 	Provider       *oidc.Provider
@@ -79,6 +80,7 @@ type Cluster struct {
 // Define our configuration
 type Config struct {
 	Clusters             []Cluster
+	Groups               map[string][]Cluster
 	Listen               string
 	Web_Path_Prefix      string
 	TLS_Cert             string
@@ -218,6 +220,18 @@ func start_app(config Config) {
 
 		if len(cluster.Scopes) == 0 {
 			cluster.Scopes = []string{"openid", "profile", "email", "offline_access", "groups"}
+		}
+
+		// Any cluster without a group will be in the 'default' group
+		if cluster.Group == "" {
+			cluster.Group = "default"
+		}
+
+		// Sort clusters by group label
+		if _, ok := config.Groups[cluster.Group]; ok {
+			config.Groups[cluster.Group] = append(config.Groups[cluster.Group], cluster)
+		} else {
+			config.Groups[cluster.Group] = []Cluster{cluster}
 		}
 
 		cluster.Config = config

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,30 +22,31 @@
       {{ end }}
     </div>
 
-    <div class="dex-container">
-
-      <div class="theme-panel">
-        <h2 class="theme-heading">Generate Kubernetes Token</h2>
-        <div>        
-            <p>
-              Select which cluster you require a token for:
-            </p>
-        
-            {{ range $cluster := .Clusters }}          
-
-            <div class="theme-form-row">
-                <p class="theme-form-description">{{$cluster.Description}}</p>
-                <a href="{{ $.Web_Path_Prefix }}login/{{$cluster.Name}}" target="_self">
-                  <button class="dex-btn theme-btn-provider">
-                    <span class="dex-btn-icon dex-btn-icon--local"></span>
-                    <span class="dex-btn-text">{{$cluster.Short_Description}}</span>
-                  </button>
-                </a>
-              </div>
-              {{ end }}
-            </div>    
+    <div class="groups-container">
+    {{ $length := len .Groups }}{{ if eq $length 1 }}<div></div>{{ end }}
+    {{ range $group, $clusters := .Groups }}
+      <div class="dex-container">
+        <div class="theme-panel">
+          <h2 class="theme-heading">{{ $group }} clusters</h2>
+          <div>        
+              <p>
+                Select which cluster you require a token for:
+              </p>
+                {{ range $cluster := $clusters }}          
+                <div class="theme-form-row">
+                    <p class="theme-form-description">{{$cluster.Description}}</p>
+                    <a href="{{ $.Web_Path_Prefix }}login/{{$cluster.Name}}" target="_self">
+                      <button class="dex-btn theme-btn-provider">
+                        <span class="dex-btn-icon dex-btn-icon--local"></span>
+                        <span class="dex-btn-text">{{$cluster.Short_Description}}</span>
+                      </button>
+                    </a>
+                </div>
+                {{ end }}
+          </div>    
         </div>
       </div>
+      {{ end }}
     </div>
   </body>
 </html>


### PR DESCRIPTION
This PR adds an option in the config to specify a 'group' for a cluster. Clusters are then displayed in the UI by group (or default, if they are assigned no group). 

When adding a lot of clusters, the single pane containing all of the clusters gets pretty hard to read. this allows us to separate out the clusters by team, environment, etc.