### PR TITLE
README: dex moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/mintel/dex-k8s-authenticator.svg?style=svg)](https://circleci.com/gh/mintel/dex-k8s-authenticator)
 
-A helper web-app which talks to one or more [Dex Identity services](https://github.com/coreos/dex) to generate
+A helper web-app which talks to one or more [Dex Identity services](https://github.com/dexidp/dex) to generate
 `kubectl` commands for creating and modifying a `kubeconfig`.
 
 The Web UI supports generating tokens against multiple cluster such as Dev / Staging / Production. 


### PR DESCRIPTION
This changes `README.md` to reflect the new Github URI for the dex project.