### PR TITLE
Added Annotations section to Deployment template

### DIFF
--- a/charts/dex-k8s-authenticator/templates/deployment.yaml
+++ b/charts/dex-k8s-authenticator/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    {{- with .Values.annotations }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
     spec:
       containers:
       - name: {{ .Chart.Name }}


### PR DESCRIPTION
To make it possible to have an annotations section defined which we can fill with data. Right now it is static data and just filled with `checksum/config:`
This makes it more flexible to give also other customized key/value pairs defined there.