### PR TITLE
Pass optional connector_id to cluster_context

### DIFF
--- a/dex-auth.go
+++ b/dex-auth.go
@@ -40,6 +40,10 @@ func (config *Config) handleIndex(w http.ResponseWriter, r *http.Request) {
 func (cluster *Cluster) handleLogin(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Handling login-uri for: %s", cluster.Name)
 	authCodeURL := cluster.oauth2Config().AuthCodeURL(exampleAppState, oauth2.AccessTypeOffline)
+	if cluster.Connector_ID != "" {
+		log.Printf("Using dex connector with id %#q", cluster.Connector_ID)
+		authCodeURL = fmt.Sprintf("%s&connector_id=%s", authCodeURL, cluster.Connector_ID)
+	}
 	log.Printf("Redirecting post-loginto: %s", authCodeURL)
 	http.Redirect(w, r, authCodeURL, http.StatusSeeOther)
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,7 @@ An example configuration is available [here](../examples/config.yaml)
 | description            | yes      | cluster | Extended description of cluster                                                       |
 | client_secret          | yes      | cluster | OAuth2 client-secret (shared between dex-k8s-auth and dex)                            |
 | client_id              | yes      | cluster | OAuth2 client-id public identifier (shared between dex-k8s-auth and dex)              |
+| connector_id           | no       | cluster | Dex connector ID to use by default omitting other available connectors                |
 | issuer                 | yes      | cluster | Dex issuer url                                                                        |
 | redirect_uri           | yes      | cluster | Redirect uri called by dex (defines a callback on dex-k8s-auth)                       |
 | k8s_master_uri         | no       | cluster | Kubernetes api-server endpoint (used in kubeconfig)                                   |

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ type Cluster struct {
 	Issuer              string
 	Client_Secret       string
 	Client_ID           string
+	Connector_ID        string
 	K8s_Master_URI      string
 	K8s_Ca_URI          string
 	K8s_Ca_Pem          string


### PR DESCRIPTION
My use-case is:
  - dex with two connectors, e.g. github with id "id1" and Microsoft with id "id2"
  - two dex-k8s-authenticator apps:
    - /login/app1 -> this should call dex with github connector
    - /login/app2 -> this should call dex with microsoft connector
The goal is to skip dex login page where you need to choose your connector.

With this change, I can configure my separate dex-k8s-authenticator apps with `connector_id: id1` and `connector_id: i2` respectively for cluster context. Then visiting a separate authenticator app will point me directly to a specified connector