### PR TITLE
Allow use of custom secret name

### DIFF
--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -55,11 +55,12 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/config.yaml"]
         env:
+        {{- $envSecretName  := .Values.envSecretName -}}
         {{- range $key, $value := .Values.envSecrets }}
         - name: {{ $key }}
           valueFrom:
             secretKeyRef:
-              name: {{ template "dex.fullname" $ }}
+              name: {{ if $envSecretName }}{{ $envSecretName }}{{ else }}{{ template "dex.fullname" $ }}{{- end }}
               key: {{ template "dex.envkey" $key }}
         {{- end }}
         ports:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -243,3 +243,6 @@ envSecrets:
   MICROSOFT_CLIENT_SECRET: "override-me"
   # LDAP
   LDAP_BINDPW: "override-me"
+
+# Name of the envSecret, only change this if you manage secret outside of this chart
+#envSecretName: custom-secret


### PR DESCRIPTION
In some (most? )cases it is preferable to manage secret outside of the chart, via eg. sealedSecrets. This PR implements feature to use custom secret name.