### PR TITLE
allow custom labels in dex-k8s-authenticator service

### DIFF
--- a/charts/dex-k8s-authenticator/templates/service.yaml
+++ b/charts/dex-k8s-authenticator/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "dex-k8s-authenticator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}


### PR DESCRIPTION
This PR add a possibility to insert custom labels in dex-k8s-authenticator service. At my work we need to include some custom labels to create the service correctly. Do you think this would be usefull for the project? 