### PR TITLE
feat(tls): reorder TLS ciphersuites and curve preference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,3 @@ RUN chmod a+x /entrypoint.sh
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 
 CMD ["--help"]
-

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func start_app(config Config) {
 	if config.Trusted_Root_Ca_File != "" {
 		content, err := ioutil.ReadFile(config.Trusted_Root_Ca_File)
 		if err != nil {
-			log.Fatalf("Failed to read file Trusted Root CA %s", config.Trusted_Root_Ca_File)
+			log.Fatalf("Failed to read file Trusted Root CA %s, %v", config.Trusted_Root_Ca_File, err)
 		}
 		ok := certp.AppendCertsFromPEM([]byte(content))
 		if !ok {
@@ -147,11 +147,26 @@ func start_app(config Config) {
 		}
 	}
 
-	mTlsConfig := &tls.Config{}
-	mTlsConfig.PreferServerCipherSuites = true
-	mTlsConfig.MinVersion = tls.VersionTLS10
-	mTlsConfig.MaxVersion = tls.VersionTLS12
-	mTlsConfig.RootCAs = certp
+	mTlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12, // minimum TLS 1.2
+		// P curve order does not matter, as breaking one means all others can be brute-forced as well:
+		// Golang developers prefer:
+		CurvePreferences:         []tls.CurveID{tls.X25519, tls.CurveP256, tls.CurveP384, tls.CurveP521},
+		PreferServerCipherSuites: true, // Server chooses ciphersuite, order matters below:
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_CHACHA20_POLY1305_SHA256, // TLS 1.3
+			tls.TLS_AES_256_GCM_SHA384,       // TLS 1.3
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_AES_128_GCM_SHA256, // TLS 1.3
+		},
+		RootCAs: certp,
+	}
 
 	tr := &http.Transport{
 		TLSClientConfig: mTlsConfig,


### PR DESCRIPTION
 - Removing insecure ciphers, pure RSA is not forward-secret
 - Curve preference for elliptic curves
 - Upgrade go.mod file to go1.16
 - Upgrade builder image to golang:1.16-alpine3.13
 - Base image upgrade to alpine:3.13
 - resolves #160

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>