### PR TITLE
Allow configuration using env in helm chart

### DIFF
--- a/charts/dex-k8s-authenticator/templates/deployment.yaml
+++ b/charts/dex-k8s-authenticator/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "--config", "config.yaml" ]
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: {{ default "5555" .Values.dexK8sAuthenticator.port }}

--- a/charts/dex-k8s-authenticator/values.yaml
+++ b/charts/dex-k8s-authenticator/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: mintel/dex-k8s-authenticator
   tag: 1.4.0
   pullPolicy: Always
- 
+
 imagePullSecrets: {}
 
 dexK8sAuthenticator:
@@ -89,6 +89,7 @@ caCerts:
   #  filename: ca2.crt
   #  value: DS1tFA1......X2F
 
+envFrom: []
 
 nodeSelector: {}
 


### PR DESCRIPTION
dex-k8s-authenticator allows usage of env variables in configuration: https://github.com/mintel/dex-k8s-authenticator/blob/98a3d45cb878f0baad9b3e19019fcbf6f9d42584/docs/config.md#environment-variable-support

but there seems to be no way to pass environment variables into the pod.

this pr allows passing data from secret as environment variables same way dex chart does it:
- https://github.com/dexidp/helm-charts/blob/8d69f098b027da77ea3f0507c7ab923a23adf6c0/charts/dex/values.yaml#L64
- https://github.com/dexidp/helm-charts/blob/8d69f098b027da77ea3f0507c7ab923a23adf6c0/charts/dex/templates/deployment.yaml#L65