### PR TITLE
Migrate to networking.k8s.io/v1 and support configuring IngressClass name

### DIFF
--- a/charts/dex-k8s-authenticator/templates/ingress.yaml
+++ b/charts/dex-k8s-authenticator/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "dex-k8s-authenticator.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -17,7 +17,10 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ $values.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
   - hosts:

--- a/charts/dex-k8s-authenticator/templates/ingress.yaml
+++ b/charts/dex-k8s-authenticator/templates/ingress.yaml
@@ -36,8 +36,11 @@ spec:
     http:
       paths:
       - path: {{ $ingressPath }}
+        pathType: Prefix
         backend:
-          serviceName: {{ $fullName }}
-          servicePort: {{ $servicePort }}
+          service:
+            name: {{ $fullName }}
+            port:
+              number: {{ $servicePort }}
   {{- end }}
 {{- end }}

--- a/charts/dex-k8s-authenticator/templates/ingress.yaml
+++ b/charts/dex-k8s-authenticator/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
 {{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ $values.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/dex-k8s-authenticator/values.yaml
+++ b/charts/dex-k8s-authenticator/values.yaml
@@ -53,6 +53,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  ingressClassName:  # "nginx"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "dex.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -17,7 +17,10 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ $values.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
   - hosts:

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -36,8 +36,11 @@ spec:
     http:
       paths:
       - path: {{ $ingressPath }}
+        pathType: Prefix
         backend:
-          serviceName: {{ $fullName }}
-          servicePort: {{ $servicePort }}
+          service:
+            name: {{ $fullName }}
+            port:
+              number: {{ $servicePort }}
   {{- end }}
 {{- end }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
 {{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ $values.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -51,6 +51,7 @@ ingress:
   #  - secretName: dex.example.com
   #    hosts:
   #      - dex.example.com
+  ingressClassName:  # "nginx"
 
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
The extensions/v1beta1 API is removed as of Kubernetes v1.22  [https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122).

This pull request adds configuration values for IngressClass name. This IngressClass resource was added in [v1.18](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/) and is now required in the ingress-nginx controller 1.0 release.