### PR TITLE
add support for customizable username field

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -21,6 +21,7 @@ An example configuration is available [here](../examples/config.yaml)
 | k8s_ca_pem_base64_encoded | no       | cluster | The Base64 encoded CA for your k8s server (used in generating instructions)           |
 | k8s_ca_pem_file           | no       | cluster | The CA file for your k8s server (used in generating instructions)                     |
 | scopes                    | no       | cluster | A list OpenID scopes to request                                                       |
+| username_field            | no       | cluster | A field that points to username                                                       |
 | tls_cert                  | no       | root    | Path to TLS cert if SSL enabled                                                       |
 | tls_key                   | no       | root    | Path to TLS key if SSL enabled                                                        |
 | idp_ca_uri                | no       | root    | A url pointing to the CA for generating 'idp-certificate-authority' in the kubeconfig |

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ type Cluster struct {
 	Client         *http.Client
 	Redirect_URI   string
 	Config         Config
-	UserName_Field         String
+	Username_Field String
 }
 
 // Define our configuration

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ type Cluster struct {
 	Client         *http.Client
 	Redirect_URI   string
 	Config         Config
+	UserName_Field         String
 }
 
 // Define our configuration

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ type Cluster struct {
 	Client         *http.Client
 	Redirect_URI   string
 	Config         Config
-	Username_Field String
+	Username_Field string
 }
 
 // Define our configuration

--- a/templates.go
+++ b/templates.go
@@ -63,8 +63,13 @@ func (cluster *Cluster) renderToken(w http.ResponseWriter,
 	}
 
 	unix_username := "user"
-	if data["email"] != nil {
-		email := data["email"].(string)
+	username_field := "email"
+	if cluster.Username_Field != "" {
+		username_field = cluster.Username_Field
+	}
+
+	if data[username_field] != nil {
+		email := data[username_field].(string)
 		unix_username = strings.Split(email, "@")[0]
 	}
 


### PR DESCRIPTION
Problem to solve:
I have an ldap backend.
dex returns an user with:
```
{
...
name: user1
email: some-email@some-domain
...
}
```
dex-k8s-authenticator creates a kubeconfig contains:
`some-email-<cluster-name>`
and I would like to have:
`user1-<cluster-name>`

Signed-off-by: Marcin Fabrykowski <git@fabrykowski.pl>