### PR TITLE
Option to handle dex-core client_secret via k8s secrets + alpine update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4-alpine3.13
+FROM golang:1.17.3-alpine3.14
 
 RUN apk add --no-cache --update alpine-sdk bash
 
@@ -15,7 +15,7 @@ COPY . .
 
 RUN make build
 
-FROM alpine:3.13.5
+FROM alpine:3.14
 
 # Dex connectors, such as GitHub and Google logins require root certificates.
 # Proper installations should manage those certificates, but it's a bad user

--- a/charts/dex-k8s-authenticator/Chart.yaml
+++ b/charts/dex-k8s-authenticator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v1.4.0"
+appVersion: "v1.4.1"
 description: "Authenticator for using Dex with Kubernetes"
 name: dex-k8s-authenticator
-version: 1.4.0
+version: 1.4.1
 sources:
 - https://github.com/mintel/dex-k8s-authenticator
 maintainers:

--- a/charts/dex-k8s-authenticator/templates/ingress.yaml
+++ b/charts/dex-k8s-authenticator/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "dex-k8s-authenticator.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/dex-k8s-authenticator/templates/secrets.yaml
+++ b/charts/dex-k8s-authenticator/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "dex-k8s-authenticator.fullname" . }}
+  labels:
+    app: {{ template "dex-k8s-authenticator.fullname" . }}
+    env: {{ default "dev" .Values.global.deployEnv }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  credentials: {{ default "" .Values.dex-core.client_secret | b64enc }}

--- a/charts/dex-k8s-authenticator/values.yaml
+++ b/charts/dex-k8s-authenticator/values.yaml
@@ -24,12 +24,19 @@ dexK8sAuthenticator:
   - name: my-cluster
     short_description: "My Cluster"
     description: "Example Cluster Long Description..."
+    #"client_secret" can be shifted to secrets.
+    #In order to use the secrets the value of client_secret needs to be replaced
+    #with the following: client_secret: ${client_secret} 
     client_secret: pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
     issuer: https://dex.example.com
     k8s_master_uri: https://my-cluster.example.com
     client_id: my-cluster
     redirect_uri: https://login.example.com/callback/my-cluster
     k8s_ca_uri: https://url-to-your-ca.crt
+
+#Will create a secret which then can be used for the "dexK8sAuthenticator->client_secret"
+#dex-core:
+#  client_secret: my-secret-value-plain
 
 service:
   annotations: {}

--- a/dex-auth.go
+++ b/dex-auth.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc"
@@ -21,11 +19,9 @@ const exampleAppState = "Vgn2lp5QnymFtLntKX5dM8k773PwcM87T4hQtiESC1q8wkUBgw5D3kH
 
 func (cluster *Cluster) oauth2Config() *oauth2.Config {
 
-	Dsec, _ := base64.StdEncoding.DecodeString(cluster.Client_Secret)
-
 	return &oauth2.Config{
 		ClientID:     cluster.Client_ID,
-		ClientSecret: strings.TrimRight((string(Dsec)), "\n"),
+		ClientSecret: cluster.Client_Secret,
 		Endpoint:     cluster.Provider.Endpoint(),
 		Scopes:       cluster.Scopes,
 		RedirectURL:  cluster.Redirect_URI,

--- a/dex-auth.go
+++ b/dex-auth.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc"
@@ -19,9 +21,11 @@ const exampleAppState = "Vgn2lp5QnymFtLntKX5dM8k773PwcM87T4hQtiESC1q8wkUBgw5D3kH
 
 func (cluster *Cluster) oauth2Config() *oauth2.Config {
 
+	Dsec, _ := base64.StdEncoding.DecodeString(cluster.Client_Secret)
+
 	return &oauth2.Config{
 		ClientID:     cluster.Client_ID,
-		ClientSecret: cluster.Client_Secret,
+		ClientSecret: strings.TrimRight((string(Dsec)), "\n"),
 		Endpoint:     cluster.Provider.Endpoint(),
 		Scopes:       cluster.Scopes,
 		RedirectURL:  cluster.Redirect_URI,

--- a/docs/config.md
+++ b/docs/config.md
@@ -73,8 +73,9 @@ clusters:
 # A path-prefix from which to serve requests and assets
 web_path_prefix: /dex-auth
 ```
-
-Don't forget to update the Dex `staticClients.redirectURIs` value to include the prefix as well.
+IMPORTANT:
+ - Don't forget to update the Dex `staticClients.redirectURIs` value to include the prefix as well.
+ - Please make sure that you Encode the `client_secret` with base64.
 
 ### Helm
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -73,9 +73,8 @@ clusters:
 # A path-prefix from which to serve requests and assets
 web_path_prefix: /dex-auth
 ```
-IMPORTANT:
- - Don't forget to update the Dex `staticClients.redirectURIs` value to include the prefix as well.
- - Please make sure that you Encode the `client_secret` with base64.
+-
+Don't forget to update the Dex `staticClients.redirectURIs` value to include the prefix as well.
 
 ### Helm
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,12 @@ if [ ! -z "$(ls -A /certs)" ]; then
   update-ca-certificates
 fi
 
+credentials_file=/var/run/secrets/dex-k8s-authenticator/credentials/credentials
+if [ -e $credentials_file ]
+then
+  echo "export client_secret" `cat $credentials_file` > /var/tmp/credential_export
+  source /var/tmp/credential_export
+fi
+
 # Execute dex-k8s-authenticator with any argument passed to docker run
 /app/bin/dex-k8s-authenticator $@


### PR DESCRIPTION
Added functionality to overcome a security query where `client_secret`is in plain text inside the config.yaml, which is stored in a config map. So now it needs to be stored as a Base64 Encoded String and then the k8s-authenticator will decrypt internally and send the secret then towards the dexidp.

Also, the Alpine version has been increased as well as the documentation is updated for the `client_secret` change.